### PR TITLE
add prototype of action buttons - with grain of scripts;

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@
 ## How to build 
 
 1. Copy config.example.toml into config.toml
-2. Build project with make
-3. 
+2. Set variables in config.toml
+3. Build project with make
+
+## How to launch
+
+1. Launch the binary
+2. Open page on address defined in `addr` config param (e.g localhost:8000)
 
 
 ## How to make new page

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -28,6 +28,10 @@ a:visited {
     flex-direction: row;
 }
 
+.action_button {
+    display: inline-block;
+}
+
 .achievement-block {
     list-style: none;
 }

--- a/web/templates/index.tmpl
+++ b/web/templates/index.tmpl
@@ -1,8 +1,18 @@
 {{ define "content" }}
 
-<a href='/logout'>Logout</a>
+<script>
+function addUrlParameter(name, value) {
+  var searchParams = new URLSearchParams(window.location.search)
+  searchParams.set(name, value)
+  window.location.search = searchParams.toString()
+}
+</script>
 
+<a href='/logout'>Logout</a>
 <br>
+<button class="action_button" href onclick="addUrlParameter('action', 'prev')">Prev</button>
+<button class="action_button" href onclick="addUrlParameter('action', 'next')">Next</button>
+<button class="action_button" href onclick="addUrlParameter('action', 'today')">Today</button>
 
 <div class="report-page">
 <div id='report' data-report-data={{ .ReportJSON }} >


### PR DESCRIPTION
Based on my idea in https://github.com/senior-sigan/toggl-reporter/issues/13

For now using a small <script> section to add action query param on button click.
If can do the same without scripts, would like to do.

Response on buttons click slower that I would like, yet it's more comfortable UX than without them, I think.